### PR TITLE
fix: Improve resiliance of reconnects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")
+
+    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 }
 
 java {

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,5 +1,5 @@
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.10"
 }
 
 def jacocoFiles = files([

--- a/src/main/kotlin/tech/relaycorp/poweb/PoWebClient.kt
+++ b/src/main/kotlin/tech/relaycorp/poweb/PoWebClient.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
+import mu.KotlinLogging
 import okhttp3.OkHttpClient
 import org.bouncycastle.util.encoders.Base64
 import tech.relaycorp.relaynet.bindings.ContentTypes
@@ -58,6 +59,8 @@ import java.security.PublicKey
 import java.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * PoWeb client.
@@ -316,6 +319,7 @@ public class PoWebClient internal constructor(
             } catch (exc: EOFException) {
                 // Connection was established, but it was just closed abruptly.
                 // E.g., the Internet connection was lost or the network changed.
+                logger.info { "WebSocket connection ended abruptly (${exc.message}). Will retry." }
                 delay(ABRUPT_DISCONNECT_RETRY_DELAY)
             } catch (exc: IOException) {
                 throw ServerConnectionException("Server is unreachable", exc)

--- a/src/main/kotlin/tech/relaycorp/poweb/PoWebClient.kt
+++ b/src/main/kotlin/tech/relaycorp/poweb/PoWebClient.kt
@@ -214,18 +214,18 @@ public class PoWebClient internal constructor(
             // The server must've closed the connection for us to get here, since we're consuming
             // all incoming messages indefinitely.
             val reason = closeReason.await()!!
-            val shouldRetry = reason.code == CloseReason.Codes.INTERNAL_ERROR.code &&
-                    streamingMode == StreamingMode.KeepAlive
-            if (shouldRetry) {
+            if (reason.code == CloseReason.Codes.NORMAL.code) {
+                return@wsConnect
+            }
+            if (streamingMode == StreamingMode.KeepAlive) {
                 throw EOFException(
-                    "WebSocket connection was terminated abruptly (${reason.message})"
-                )
-            } else if (reason.code != CloseReason.Codes.NORMAL.code) {
-                throw ServerConnectionException(
-                    "Server closed the connection unexpectedly " +
-                            "(code: ${reason.code}, reason: ${reason.message})"
+                    "WebSocket connection was terminated abruptly (code: ${reason.code})"
                 )
             }
+            throw ServerConnectionException(
+                "Server closed the connection unexpectedly " +
+                        "(code: ${reason.code}, reason: ${reason.message})"
+            )
         }
     }
 

--- a/src/test/kotlin/tech/relaycorp/poweb/ParcelCollectionTest.kt
+++ b/src/test/kotlin/tech/relaycorp/poweb/ParcelCollectionTest.kt
@@ -151,7 +151,7 @@ class ParcelCollectionTest : WebSocketTestCase() {
             addServerConnection(ChallengeAction(nonce), CloseConnectionAction())
 
             client.use {
-                client.collectParcels(arrayOf(signer)).collect { }
+                client.collectParcels(arrayOf(signer)).toList()
             }
 
             waitForConnectionClosure()
@@ -181,29 +181,6 @@ class ParcelCollectionTest : WebSocketTestCase() {
                 )
             }
         }
-
-        @Test
-        fun `Exception should be thrown if mode is Keep-Alive and code is not INTERNAL_ERROR`() =
-            runTest {
-                val code = CloseReason.Codes.VIOLATED_POLICY
-                val reason = "Whoops"
-                addServerConnection(ChallengeAction(nonce), CloseConnectionAction(code, reason))
-
-                client.use {
-                    val exception = assertThrows<ServerConnectionException> {
-                        client.collectParcels(
-                            arrayOf(signer),
-                            StreamingMode.KeepAlive
-                        ).toList()
-                    }
-
-                    assertEquals(
-                        "Server closed the connection unexpectedly " +
-                                "(code: ${code.code}, reason: $reason)",
-                        exception.message
-                    )
-                }
-            }
 
         @Test
         fun `Should be reconnected if mode is Keep-Alive and code is INTERNAL_ERROR`() = runTest {

--- a/src/test/kotlin/tech/relaycorp/poweb/ParcelCollectionTest.kt
+++ b/src/test/kotlin/tech/relaycorp/poweb/ParcelCollectionTest.kt
@@ -219,10 +219,7 @@ class ParcelCollectionTest : WebSocketTestCase() {
             )
 
             client.use {
-                client.collectParcels(
-                    arrayOf(signer),
-                    StreamingMode.KeepAlive
-                ).toList()
+                client.collectParcels(arrayOf(signer), StreamingMode.KeepAlive).toList()
 
                 waitForConnectionClosure()
             }


### PR DESCRIPTION
- Reimplement handling of WebSocket `1011` closures non-recursively.
- Add logging.